### PR TITLE
add delegation feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,9 +56,9 @@ checksum = "6b2d54853319fd101b8dd81de382bcbf3e03410a64d8928bbee85a3e7dcde483"
 
 [[package]]
 name = "anchor-attribute-access-control"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ff7b54a5d232ce177fb5e1d42bb767678e5df0434b205a045afa8fc7a83a23"
+checksum = "86d2149326aaeabca2e8b4066a0b87be7391836580e760f5a7604869d535f09d"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -70,9 +70,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-account"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f2c53504cae7e67cd4d7a2d6db6828293923c0a0d80e8ae29e67bf517548d6e"
+checksum = "0eb8021477a12b567601537cd6ff91a3263637e8dc10a28e5e48d9054a882332"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -85,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-error"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8341b2661f13ca6e4dfb55e21f49908774d9fb915c56dbd7b804668c3eb53380"
+checksum = "b9a9f98d3337ae3fc83c387474a6a9749d65331f7e035cfef8f0b71a7f00b5a5"
 dependencies = [
  "anchor-syn",
  "proc-macro2 1.0.29",
@@ -97,9 +97,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-event"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e5e4e868c019d872baa669b43796a877e6a66da4a286a1b8467ba747428804d"
+checksum = "383257ed3b0cf25cc237209192f18b6645b3cc70f1e86e8e09aa9556ee9cb176"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -110,9 +110,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-interface"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db9d1de704bf2845d9edc7fe368a48943b672f2e770251c4d929d6712bac367d"
+checksum = "89327bd11fae68883aacd3a60f8ac964fa90ea869ba405f185b99afa00a07d5f"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -124,9 +124,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-program"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f035ee71ffa1db5f06694a650aa61ba4265f9fa1263fed3b744b2cd8a31f448a"
+checksum = "1c7a3995e58991ed860b65c4eb226587bf62bf7d5888259505ca3640abf2046f"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -137,9 +137,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-state"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1a2bfe33f0fc0aeffe01dda3aa36417eb96ebcfc39dfdb003ef968d5ed9a70f"
+checksum = "aecfa2eb94ff4f8a76c1778dfa072ef91476648b0b17c1271d69650b5d5a8bff"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -166,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-derive-accounts"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fffb0562db113cd2491e825e0f4df8d050dc14371dec7cccf757efcf86445451"
+checksum = "4d1d5fe450cb0846a8739bc119e900797a563dccbdde6eff1161acbd98acc33c"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -179,9 +179,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-lang"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd220aca840a0067d43da61e802a5e4ac13582f0baef7aa33c79d42a0110086"
+checksum = "bfa99ba6c97bf37cd393ff8ba9dfa548344d771ac1f4de104a674cd873e955cb"
 dependencies = [
  "anchor-attribute-access-control",
  "anchor-attribute-account",
@@ -213,9 +213,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-syn"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93cade4d95b7edd8d6be4e8243b935e26dee6eb1a50bd226392cefd0a31e682c"
+checksum = "05808f141957f3c946d24335f2e1c94054147945baceac24e4840303247180e1"
 dependencies = [
  "anyhow",
  "bs58 0.3.1",

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -16,6 +16,8 @@ pub struct Opts {
 #[derive(Clap)]
 pub enum Job {
     New(CreateMultisig),
+    AddDelegates(Delegates),
+    RemoveDelegates(Delegates),
     Approve(Transaction),
     Execute(Transaction),
     Get,
@@ -34,6 +36,11 @@ pub struct CreateMultisig {
     pub threshold: u64,
     #[clap(required = true)]
     pub owners: Vec<Pubkey>,
+}
+
+#[derive(Clap, Debug)]
+pub struct Delegates {
+    pub delegates: Vec<Pubkey>,
 }
 
 #[derive(Clap, Debug)]

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -21,4 +21,13 @@ pub struct MultisigConfig {
 
     #[serde(with = "serde_with::rust::display_fromstr")]
     pub multisig: Pubkey,
+
+    pub delegation: Option<DelegationConfig>,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "kebab-case")]
+pub struct DelegationConfig {
+    #[serde(with = "serde_with::rust::display_fromstr")]
+    pub owner: Pubkey,
 }

--- a/cli/src/request_builder.rs
+++ b/cli/src/request_builder.rs
@@ -109,7 +109,7 @@ impl<'a> RequestBuilder<'a> {
         self
     }
 
-    pub fn send(self) -> Result<Signature, ClientError> {
+    pub fn send(self, preflight: bool) -> Result<Signature, ClientError> {
         let accounts = match self.namespace {
             RequestNamespace::State { new } => {
                 let mut accounts = match new {
@@ -162,7 +162,7 @@ impl<'a> RequestBuilder<'a> {
         };
 
         let mut config = RpcSendTransactionConfig::default();
-        config.skip_preflight = true;
+        config.skip_preflight = !preflight;
 
         // rpc_client
         // .send_transaction_with_config(&tx, config)

--- a/programs/multisig/Cargo.toml
+++ b/programs/multisig/Cargo.toml
@@ -16,4 +16,4 @@ cpi = ["no-entrypoint"]
 default = []
 
 [dependencies]
-anchor-lang = "0.16.1"
+anchor-lang = "0.16.2"


### PR DESCRIPTION
- allow owners to delegate their signing authority to other addresses

new instructions:

- `create_delegate_list` - Setup an account to record delegated signing authority for an owner in a multisig.
- `set_delegate_list` - Change the list of addresses with delegated signing authority. Can be changed by the owner directly, or by approval via the multisig.
- `delegate_approve` - Analog of `approve`, but when the approver is a delegated address instead of the owner.

modified instructions:

- `create_transaction` - Now takes an extra (optional) account, which is assumed to be the account for a delegate list. This allows a delegated address to also propose new transactions.

CLI is also updated to include `add-delegates` and `remove-delegates` commands.

### Motivation 

This functionally allows a user to use multiple addresses to sign multisig approvals with. This is useful as it allows a single signer to have a root key with a more strict security posture that can be used to rotate/revoke more easily accessible keys that are used in potentially less secure environments.